### PR TITLE
Add keep-alive workflow

### DIFF
--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -1,0 +1,18 @@
+name: Keep
+on:
+  # pull_request:
+  schedule:
+    - cron: "0 6 * * SUN"  # Once weekly on Sunday @ 0600 UTC 
+
+jobs:
+  keep-alive:
+    name: Alive
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: gautamkrishnar/keepalive-workflow@1b33e4ef553c59eef0e3450666408021f4b0f456
+        with:
+          commit_message: "Ah ah ah, stayin' alive"
+          committer_username: ForrestQuant
+          committer_email: "forrestquant@users.noreply.github.com"
+          time_elapsed: 50  # days


### PR DESCRIPTION
We didn't get mypy updates as we haven't committed on master for 60 days. Due to inactivity, Github Actions disabled the workflow. This should prevent this from happening again.